### PR TITLE
[#1773] Adding cuda-12 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 The gigrouter-examples repository contains:
 
 * Examples of (mostly k3s) user applications
+* [Instructions for installing CUDA 12](./cuda-12)
 * Functional tools
 * System software for the GigRouter
 

--- a/cuda-12/README.md
+++ b/cuda-12/README.md
@@ -1,0 +1,59 @@
+# CUDA 12.2 Installation and Usage
+
+This doc has instructions for installing and configuring CUDA 12.2 & nvidia-container-toolkit on GigRouters running L4T R35.5.0. Both of these pieces of software are necessary for running containerized cuda-12 workloads.
+
+## Quick Start
+
+### Installing CUDA 12.2 and nvidia container runtime
+
+The `install-cuda12.sh` script will install both `cuda-12.2` and `nvidia-container-toolkit`. It will also perform a few configuration steps so that the `nvidia-container-runtime` points at cuda-12.2 instead of the system default (cuda-11.4).
+
+Copy the `install-cuda12.sh` script over to your GigRouter and run as root:
+
+```bash
+sudo ./install-cuda12.sh
+```
+
+This script will do the following:
+- Add a CUDA apt source
+- Install cuda-12.2
+- Add cuda-12.2 compatability libs to ldcache
+- Install nvidia-container-toolkit
+- Configure the nvidia-container-runtime to point at cuda-12.2 instead of the system default (cuda-11.4)
+
+### Verifying CUDA 12.2 is working
+
+After the installation completes you can use the `verify-cuda12-docker.sh` script to verify cuda-12.2 is installed and accessible from docker containers.
+
+Copy the `verify-cuda12-docker.sh` script over to your GigRouter and run:
+
+```bash
+./verify-cuda12-docker.sh
+```
+
+This script will do the following:
+- Install docker
+- Give docker access to the nvidia-container-runtime
+- Clone the [cuda-samples repo](https://github.com/NVIDIA/cuda-samples)
+- Build and run the `deviceQuery` sample under the `nvidia/cuda:12.2.0-base-ubuntu20.04` docker image
+- Build and run the `transpose` sample under the `nvidia/cuda:12.2.0-base-ubuntu20.04` docker image
+
+### Using CUDA 12.2 under Docker
+
+CUDA is accessible under Docker (or other container runtimes) thanks to the nvidia-container-runtime.
+
+Before running containerized workloads you'll need to configure the runtime. The following will configure docker:
+
+```bash
+sudo nvidia-ctk runtime continure --runtime=docker
+sudo systemctl restart docker
+```
+
+Other container engines can be configured by following [these instructions](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#configuration).
+
+You can run a dockerized workload by using the following flags: `--runtime=nvidia --gpus all`, like so:
+```bash
+sudo docker run --rm --runtime=nvidia --gpus all  nvidia/cuda:12.2.0-base-ubuntu20.04 <workload>
+```
+
+See [here](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/sample-workload.html#running-a-sample-workload) for instructions for running CUDA workloads under other container engines.

--- a/cuda-12/install-cuda12.sh
+++ b/cuda-12/install-cuda12.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # This script installs and configures cuda-12.2 and nvidia-container-toolkit for usage on L4T R35.5.0 systems.
 
 # Check if running as root
@@ -10,14 +12,13 @@ fi
 
 # Add cuda apt source and install cuda 12
 
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/arm64/cuda-keyring_1.1-1_all.deb
-dpkg -i cuda-keyring_1.1-1_all.deb
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/arm64/cuda-keyring_1.1-1_all.deb -O /tmp/cuda-keyring.deb
+dpkg -i /tmp/cuda-keyring.deb
 apt-get update
 apt install -y cuda
 
-
 # Add cuda-12 compat to ldcache
-echo "/usr/local/cuda-12.2/compat" | tee -a /etc/ld.so.conf.d/988_cuda-12-compat.conf
+echo "/usr/local/cuda-12.2/compat" | tee /etc/ld.so.conf.d/988_cuda-12-compat.conf
 ldconfig
 
 # Install nvidia-container-toolkit
@@ -30,3 +31,6 @@ sed -i -e 's|/usr/lib/aarch64-linux-gnu/tegra/libcuda.so.1.1|/usr/local/cuda-12.
 sed -i -e 's|/usr/lib/aarch64-linux-gnu/libcuda.so|/usr/local/cuda-12.2/compat/libcuda.so|g' /etc/nvidia-container-runtime/host-files-for-container.d/l4t.csv
 sed -i -e '\|/usr/lib/aarch64-linux-gnu/tegra/libcuda.so|d' /etc/nvidia-container-runtime/host-files-for-container.d/l4t.csv
 sed -i -e 's|/usr/lib/aarch64-linux-gnu/tegra/libcuda.so.1|/usr/local/cuda-12.2/compat/libcuda.so.1|g' /etc/nvidia-container-runtime/host-files-for-container.d/l4t.csv
+
+echo ""
+echo "cuda-12.2 and nvidia-container-toolkit installed and configured to work together!!"

--- a/cuda-12/install-cuda12.sh
+++ b/cuda-12/install-cuda12.sh
@@ -15,7 +15,7 @@ fi
 wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/arm64/cuda-keyring_1.1-1_all.deb -O /tmp/cuda-keyring.deb
 dpkg -i /tmp/cuda-keyring.deb
 apt-get update
-apt install -y cuda
+apt install -y cuda=12.2.2-1
 
 # Add cuda-12 compat to ldcache
 echo "/usr/local/cuda-12.2/compat" | tee /etc/ld.so.conf.d/988_cuda-12-compat.conf

--- a/cuda-12/install-cuda12.sh
+++ b/cuda-12/install-cuda12.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# This script installs and configures cuda-12.2 and nvidia-container-toolkit for usage on L4T R35.5.0 systems.
+
+# Check if running as root
+if [ "$EUID" -ne 0 ]; then
+    echo "Please run as root"
+    exit 1
+fi
+
+# Add cuda apt source and install cuda 12
+
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/arm64/cuda-keyring_1.1-1_all.deb
+dpkg -i cuda-keyring_1.1-1_all.deb
+apt-get update
+apt install -y cuda
+
+
+# Add cuda-12 compat to ldcache
+echo "/usr/local/cuda-12.2/compat" | tee -a /etc/ld.so.conf.d/988_cuda-12-compat.conf
+ldconfig
+
+# Install nvidia-container-toolkit
+
+apt install -y nvidia-container-toolkit
+
+# Modify nvidia-container-runtime config to look at cuda-12 libs
+
+sed -i -e 's|/usr/lib/aarch64-linux-gnu/tegra/libcuda.so.1.1|/usr/local/cuda-12.2/compat/libcuda.so.1.1|g' /etc/nvidia-container-runtime/host-files-for-container.d/l4t.csv
+sed -i -e 's|/usr/lib/aarch64-linux-gnu/libcuda.so|/usr/local/cuda-12.2/compat/libcuda.so|g' /etc/nvidia-container-runtime/host-files-for-container.d/l4t.csv
+sed -i -e '\|/usr/lib/aarch64-linux-gnu/tegra/libcuda.so|d' /etc/nvidia-container-runtime/host-files-for-container.d/l4t.csv
+sed -i -e 's|/usr/lib/aarch64-linux-gnu/tegra/libcuda.so.1|/usr/local/cuda-12.2/compat/libcuda.so.1|g' /etc/nvidia-container-runtime/host-files-for-container.d/l4t.csv

--- a/cuda-12/install-cuda12.sh
+++ b/cuda-12/install-cuda12.sh
@@ -9,6 +9,18 @@ if [ "$EUID" -ne 0 ]; then
     echo "Please run as root"
     exit 1
 fi
+# Verify we're on Ubuntu 20.04
+if [[ -r /etc/os-release ]]; then
+  # load NAME, VERSION_ID, PRETTY_NAME, etc.
+  . /etc/os-release
+  if [[ "$NAME" != "Ubuntu" || "$VERSION_ID" != "20.04" ]]; then
+    echo "Error: This script only runs on L4T R35.5.0 (Ubuntu 20.04). Detected: $PRETTY_NAME" >&2
+    exit 1
+  fi
+else
+  echo "Error: Unable to determine OS version (missing /etc/os-release)" >&2
+  exit 1
+fi
 
 # Add cuda apt source and install cuda 12
 

--- a/cuda-12/verify-cuda12-docker.sh
+++ b/cuda-12/verify-cuda12-docker.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Install docker
+
+sudo apt install -y docker.io
+
+# Configure docker with nvidia-container-runtime toolkit
+
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+
+# Grab cuda-samples for sample workloads
+
+cd ~
+git clone https://github.com/NVIDIA/cuda-samples.git
+cd cuda-samples
+git checkout v12.2
+
+# Test deviceQuery
+
+cd Samples/1_Utilities/deviceQuery
+make -j8
+sudo docker run --rm --runtime=nvidia --gpus all -v .:/test nvidia/cuda:12.2.0-base-ubuntu20.04 bash -c "cd /test && ./deviceQuery"
+
+# Test transpose
+
+cd ../6_Performance/transpose
+make -j8
+sudo docker run --rm --runtime=nvidia --gpus all -v .:/test nvidia/cuda:12.2.0-base-ubuntu20.04 bash -c "cd /test && ./transpose"

--- a/cuda-12/verify-cuda12-docker.sh
+++ b/cuda-12/verify-cuda12-docker.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # Install docker
 
 sudo apt install -y docker.io
@@ -16,14 +18,17 @@ git clone https://github.com/NVIDIA/cuda-samples.git
 cd cuda-samples
 git checkout v12.2
 
+# Build samples
+
+make -j8 PROJECTS=Samples/1_Utilities/deviceQuery/Makefile
+make -j8 PROJECTS=Samples/6_Performance/transpose/Makefile
+
 # Test deviceQuery
 
-cd Samples/1_Utilities/deviceQuery
-make -j8
-sudo docker run --rm --runtime=nvidia --gpus all -v .:/test nvidia/cuda:12.2.0-base-ubuntu20.04 bash -c "cd /test && ./deviceQuery"
+sudo docker run --rm --runtime=nvidia --gpus all -v ./bin/aarch64/linux/release:/test nvidia/cuda:12.2.0-base-ubuntu20.04 bash -c "cd /test && ./deviceQuery"
 
 # Test transpose
 
-cd ../6_Performance/transpose
-make -j8
-sudo docker run --rm --runtime=nvidia --gpus all -v .:/test nvidia/cuda:12.2.0-base-ubuntu20.04 bash -c "cd /test && ./transpose"
+sudo docker run --rm --runtime=nvidia --gpus all -v ./bin/aarch64/linux/release:/test nvidia/cuda:12.2.0-base-ubuntu20.04 bash -c "cd /test && ./transpose"
+
+cd ~

--- a/cuda-12/verify-cuda12-docker.sh
+++ b/cuda-12/verify-cuda12-docker.sh
@@ -31,4 +31,6 @@ sudo docker run --rm --runtime=nvidia --gpus all -v ./bin/aarch64/linux/release:
 
 sudo docker run --rm --runtime=nvidia --gpus all -v ./bin/aarch64/linux/release:/test nvidia/cuda:12.2.0-base-ubuntu20.04 bash -c "cd /test && ./transpose"
 
-cd ~
+echo ""
+echo "Verified CUDA examples successfully ran under docker container!!"
+echo "You may choose to explore other examples or remove CUDA examples directory: ~/cuda-samples"


### PR DESCRIPTION
Closes cambrianworks/gigrouter#1773

## Description

Packages up installation/configuration/verification instructions for cuda-12.2 on R35.5.0 in an example format.

## Testing Steps

- Test "install" and "verify" scripts on a GigRouter and verify everything is successful/works (gr3 is a great one to use)